### PR TITLE
Rename binary back to be prefixed with "cargo"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ log = { version = "0.4", default-features = false }
 env_logger= { version = "0.10", default-features = false }
 
 [[bin]]
-name = "unused-features"
+name = "cargo-unused-features"
 path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 This cargo tool allows you to find and prune enabled, but, [potentially](#3-some-things-to-keep-in-mind) unused feature flags from your project.
 
-Use `unused-features --help` to fetch more details about available subcommands and their configurations.
+Use `cargo unused-features --help` to fetch more details about available subcommands and their configurations.
 
 # 1. How to use
 
@@ -22,7 +22,7 @@ Run `cargo install cargo-unused-features` or download the library and build it y
 
 ```bash
 cd C:/some_path/
-unused-features analyze
+cargo unused-features analyze
 ```
 
 After it finished running, check the `report.json` in the project directory and use this for the next two steps.
@@ -34,7 +34,7 @@ You can generate a simple HTML report from the json to make it easier to inspect
 <img src="docs/readme-1.jpg" />
 
 ```bash
-unused-features build-report --input "C:/some_path/report.json"
+cargo unused-features build-report --input "C:/some_path/report.json"
 ```
 
 After it finished running, check the `report.html` in the project directory. You can choose to manually fix your dependencies or use the command in the next step.
@@ -44,7 +44,7 @@ After it finished running, check the `report.html` in the project directory. You
 It is possible to auto-apply the findings of the first command. But keep in mind the [disclaimers](#3-some-things-to-keep-in-mind).
 
 ```bash
-unused-features prune --input "C:/some_path/report.json"
+cargo unused-features prune --input "C:/some_path/report.json"
 ```
 
 # 2. How it Works

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -8,7 +8,7 @@ use self::{analyze::AnalyzeCommand, prune::PruneCommand, report_builder::ReportB
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
-#[clap(name = "unused-features")]
+#[clap(name = "cargo-unused-features")]
 pub enum Cargo {
     Analyze(AnalyzeCommand),
     BuildReport(ReportBuildingCommand),

--- a/src/subcommands/report_builder.rs
+++ b/src/subcommands/report_builder.rs
@@ -7,7 +7,8 @@ use clap::Args;
 
 use crate::{utils, Report, ReportDependencyEntry};
 
-/// Builds a simple HTML report from the output file of the `unused-features analyze` subcommand.
+/// Builds a simple HTML report from the output file of the `cargo unused-features analyze`
+/// subcommand.
 #[derive(Args, Debug, Clone, Default)]
 #[clap(author, version)]
 #[clap(setting = clap::AppSettings::DeriveDisplayOrder)]


### PR DESCRIPTION
It is highly confusing that the project is named "cargo-unused-features" but the binary is called "unused-features".

Thus rename the binary to "cargo-unused-features".