### PR TITLE
Only trigger workspace analysis if there are workspace members

### DIFF
--- a/src/cargo_project.rs
+++ b/src/cargo_project.rs
@@ -26,8 +26,6 @@ pub struct CargoProject {
     directory: Box<Path>,
     /// The absolute path of the toml file.
     toml_path: Box<Path>,
-    /// Is the toml describing a workspace.
-    is_workspace: bool,
     /// The in memory loaded toml definition that can be edited and serialized.
     in_memory_toml: TomlInMemory,
     /// Configurations.
@@ -52,13 +50,10 @@ impl CargoProject {
 
         log::debug!("Successfully parsed the toml file.");
 
-        let is_workspace = in_memory_toml.workspace.is_some();
-
         Ok(CargoProject {
             original: toml_contents,
             directory: Box::from(directory),
             toml_path: toml_path.into_boxed_path(),
-            is_workspace,
             in_memory_toml,
             config,
         })
@@ -67,11 +62,6 @@ impl CargoProject {
     /// Returns the configuration.
     pub fn config(&self) -> &AnalyzeCommand {
         &self.config
-    }
-
-    /// Returns if this toml file is a workspace.
-    pub fn is_workspace(&self) -> bool {
-        self.is_workspace
     }
 
     /// Returns a list of absolute path names to the workspace members of this toml file.

--- a/src/subcommands/analyze.rs
+++ b/src/subcommands/analyze.rs
@@ -71,12 +71,13 @@ impl AnalyzeCommand {
 
         match CargoProject::new(crate_path, self.clone()) {
             Ok(root_toml) => {
-                if root_toml.is_workspace() {
+                let workspace_members = root_toml.workspace_members();
+                if !workspace_members.is_empty() {
                     log::debug!("Workspace detected, iterating over workspace crates...");
 
                     let mut report = Report::new("Workspace");
 
-                    for member_path in root_toml.workspace_members() {
+                    for member_path in workspace_members {
                         log::debug!("Processing '{}' crate ...", member_path.display());
 
                         match CargoProject::new(&member_path, self.clone()) {


### PR DESCRIPTION
We would previously trigger workspace analysis if a `Cargo.toml` had any `workspace` entry even though we ultimately cared about `workspace.members`. This caused empty reports for files which used `workspace` only for configuration like e.g., entries created by `cargo-dist`.

With this patch we handle a workspace only if `workspace.members` is present. We also simplify the code since we do not need to inject anymore wheter a project "uses" workspaces (i.e., has workspace members).

Closes #22.